### PR TITLE
changed signin & signup router

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -19,7 +19,7 @@ const bodyParser = require("body-parser");
 /* GET home page. */
 router.get("/", services.homeRoutes);
 
-router.get("/register", services.registerRoutes);
+router.get("/sign", services.signRoutes);
 
 /* register api */
 router.post("/register", function (req, res) {
@@ -155,6 +155,20 @@ router.post("/qna/question", function (req, res) {
     const category = req.body.category || "";
     const timestamp = req.body.timestamp || "";
     const main_text = req.body.main_text || "";
+
+    if (
+      !title.length ||
+      !writer_id.length ||
+      !category.length ||
+      !main_text.length
+    ) {
+      return res.status(401).json({
+        post: false,
+        err: "Invalid field value",
+      });
+    }
+
+    const query = `SELECT * FROM questions `;
   } catch (e) {
     console.log(e);
   }

--- a/server/services/render.js
+++ b/server/services/render.js
@@ -5,6 +5,6 @@ exports.homeRoutes = (req, res) => {
   });
 };
 
-exports.registerRoutes = (req, res) => {
+exports.signRoutes = (req, res) => {
   res.render("signIn");
 };


### PR DESCRIPTION
로그인과 회원가입을 같은 페이지에서 진행하기로 결정함에 따라, 이에 적절한 주소를 재할당 하여 수정했습니다.
앞으로 로그인 & 회원가입의 동작은 schoolmate.school/sign 페이지에서 진행될 예정입니다.

앞서서 보낸 PR은 실수입니다!! 1차적인 수정은 front와 end에, 2차적인 수정은 develop, 3차 테스트는 test branch에서 진행합니다!